### PR TITLE
Greedy quotes fix

### DIFF
--- a/lib/sql-parser/parser.rex
+++ b/lib/sql-parser/parser.rex
@@ -20,18 +20,18 @@ rule
 # [:state]  pattern       [actions]
 
 # literals
-            \"{DATE}\"    { [:date_string, Date.parse(text)] }
-            \'{DATE}\'    { [:date_string, Date.parse(text)] }
+            \"{DATE}\"      { [:date_string, Date.parse(text)] }
+            \'{DATE}\'      { [:date_string, Date.parse(text)] }
 
-            \'            { @state = :STRS;  [:quote, text] }
-  :STRS     \'            { @state = nil;    [:quote, text] }
-  :STRS     .*(?=\')      {                  [:character_string_literal, text.gsub("''", "'")] }
+            \'              { @state = :STRS;  [:quote, text] }
+  :STRS     \'(?=[^\']|$)   { @state = nil;    [:quote, text] }
+  :STRS     (?:[^\']|\'\')* {                  [:character_string_literal, text.gsub("''", "'")] }
 
-            \"            { @state = :STRD;  [:quote, text] }
-  :STRD     \"            { @state = nil;    [:quote, text] }
-  :STRD     .*(?=\")      {                  [:character_string_literal, text.gsub('""', '"')] }
+            \"              { @state = :STRD;  [:quote, text] }
+  :STRD     \"(?=[^\"]|$)   { @state = nil;    [:quote, text] }
+  :STRD     (?:[^\"]|\"\")* {                  [:character_string_literal, text.gsub('""', '"')] }
 
-            {UINT}        { [:unsigned_integer, text.to_i] }
+            {UINT}          { [:unsigned_integer, text.to_i] }
 
 # built-in functions
             {IDENT}\(\)   { [:built_in_function, text] }

--- a/lib/sql-parser/parser.rex.rb
+++ b/lib/sql-parser/parser.rex.rb
@@ -280,10 +280,10 @@ class SQLParser::Parser < Racc::Parser
 
     when :STRS
       case
-      when (text = @ss.scan(/\'/i))
+      when (text = @ss.scan(/\'(?=[^\']|$)/i))
          action { @state = nil;    [:quote, text] }
 
-      when (text = @ss.scan(/.*(?=\')/i))
+      when (text = @ss.scan(/(?:[^\']|\'\')*/i))
          action {                  [:character_string_literal, text.gsub("''", "'")] }
 
       else
@@ -293,10 +293,10 @@ class SQLParser::Parser < Racc::Parser
 
     when :STRD
       case
-      when (text = @ss.scan(/\"/i))
+      when (text = @ss.scan(/\"(?=[^\"]|$)/i))
          action { @state = nil;    [:quote, text] }
 
-      when (text = @ss.scan(/.*(?=\")/i))
+      when (text = @ss.scan(/(?:[^\"]|\"\")*/i))
          action {                  [:character_string_literal, text.gsub('""', '"')] }
 
       else

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -312,14 +312,13 @@ class TestParser < Test::Unit::TestCase
     assert_understands %{SELECT 'Quote ''this!'''}
 
     assert_sql(
-      %{SELECT `a` FROM `b` WHERE `a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%'},
+      %{SELECT `a` FROM `b` WHERE (`a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%')},
       %{SELECT `a` FROM `b` WHERE `a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%'}
     )
-    assert_understands %{SELECT `a` FROM `b` WHERE `a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%'}
+    assert_understands %{SELECT `a` FROM `b` WHERE (`a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%')}
 
-    # # FIXME
-    # assert_sql %{SELECT '"'}, %{SELECT """"}
-    # assert_understands %{SELECT ''''}
+    assert_sql %{SELECT '"'}, %{SELECT """"}
+    assert_understands %{SELECT ''''}
   end
 
   def test_string

--- a/test/test_parser.rb
+++ b/test/test_parser.rb
@@ -311,6 +311,12 @@ class TestParser < Test::Unit::TestCase
     assert_sql %{SELECT 'Quote "this"'}, %{SELECT "Quote ""this"""}
     assert_understands %{SELECT 'Quote ''this!'''}
 
+    assert_sql(
+      %{SELECT `a` FROM `b` WHERE `a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%'},
+      %{SELECT `a` FROM `b` WHERE `a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%'}
+    )
+    assert_understands %{SELECT `a` FROM `b` WHERE `a`.`c` LIKE '%1%' AND `a`.`d` LIKE '%2%'}
+
     # # FIXME
     # assert_sql %{SELECT '"'}, %{SELECT """"}
     # assert_understands %{SELECT ''''}


### PR DESCRIPTION
Improves the quotes regexes to support two additional use cases:

1. Two independent quoted parameters
2. Double escaped " inside a "

Changes regexes so that:
1. Starting regex is not changed
2. Ending regex is changed such that it matches only a single repetition of the end character.
3. Inner regex is changed such that it matches all instances of anything other than a single instance of the end character.